### PR TITLE
If there is no widget, Don't show 'Remove Widget'

### DIFF
--- a/launcher/src/main/java/de/clemensbartz/android/launcher/Launcher.java
+++ b/launcher/src/main/java/de/clemensbartz/android/launcher/Launcher.java
@@ -598,7 +598,7 @@ public final class Launcher extends Activity {
         @Override
         public void onCreateContextMenu(final ContextMenu contextMenu, final View view, final ContextMenu.ContextMenuInfo contextMenuInfo) {
             contextMenu.add(0, ITEM_CHOOSE_WIDGET, 0, R.string.choose_widget);
-            contextMenu.add(0, ITEM_REMOVE_WIDGET, 0, R.string.remove_widget);
+            if (model.getAppWidgetId() != -1) contextMenu.add(0, ITEM_REMOVE_WIDGET, 0, R.string.remove_widget);
         }
     }
 


### PR DESCRIPTION
While using the App I have noticed that the 'Remove Widget' Context Options Menu Item is always shown.  While this does not cause any issues in using the App it does lead to an awkward UI in certain scenarios.

This change is adding an if statement to a single line of code in the Launcher.java file at line 601. 

Build Information:
* Android Studio 3.1.1
* Android Gradle Build Tools 3.0.1
* Build Tools 27.0.2
* Target/Compile API 27
* Min API 21

APK Size: 27.0 KB
Download Size: 23.2 KB
