### PR TITLE
Add gestures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,10 +53,10 @@ jobs:
             profile: Nexus 6
             arch: x86_64
             target: default
-          - api-level: 29 # latest one always google_apis
+          - api-level: 29
             profile: Nexus 6
             arch: x86_64
-            target: google_apis
+            target: default
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,8 +58,6 @@ jobs:
             arch: x86_64
             target: google_apis
     steps:
-      - name: clean
-        run: ./gradlew clean
       - name: checkout
         uses: actions/checkout@v2
       - name: ${{ matrix.devices.profile }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Test with Gradle
         run: ./gradlew test
   build:
-    needs: test
+    needs: lintRelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -36,7 +36,7 @@ jobs:
       - name: Build with Gradle
         run: ./gradlew build
   connectedCheck:
-    needs: build
+    needs: lintRelease
     runs-on: macOS-latest
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,10 @@ jobs:
             arch: x86_64
             target: google_apis
     steps:
+      - name: clean
+        run: ./gradlew clean
       - name: checkout
         uses: actions/checkout@v2
-
       - name: ${{ matrix.devices.profile }}
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,7 @@ jobs:
       - name: Test with Gradle
         run: ./gradlew lintRelease -x lint --stacktrace
   test:
+    needs: lintRelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -23,7 +24,19 @@ jobs:
           java-version: 1.8
       - name: Test with Gradle
         run: ./gradlew test
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build with Gradle
+        run: ./gradlew build
   connectedCheck:
+    needs: build
     runs-on: macOS-latest
     strategy:
       matrix:
@@ -58,13 +71,3 @@ jobs:
           emulator-options: -no-window -gpu swiftshader_indirect -no-snapshot -noaudio -no-boot-anim
           disable-animations: true
           script: ./gradlew connectedCheck
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - name: Set up JDK 1.8
-        uses: actions/setup-java@v1
-        with:
-          java-version: 1.8
-      - name: Build with Gradle
-        run: ./gradlew build

--- a/launcher/src/androidTest/java/de/clemensbartz/android/launcher/ActionBarTest.java
+++ b/launcher/src/androidTest/java/de/clemensbartz/android/launcher/ActionBarTest.java
@@ -19,11 +19,14 @@ package de.clemensbartz.android.launcher;
 
 import android.app.ActionBar;
 
+import androidx.test.espresso.IdlingRegistry;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import de.clemensbartz.androidx.resources.WaitingIdlingResource;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.Espresso.openActionBarOverflowOrOptionsMenu;
@@ -51,6 +54,10 @@ public class ActionBarTest extends AbstractTest {
         // Check that action bar is hidden
         final ActionBar actionBar = launcherActivityTestRule.getActivity().getActionBar();
 
+        // Wait for 500 milliseconds to wait for the resolution of events
+        final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(500);
+        IdlingRegistry.getInstance().register(waitingIdlingResource);
+
         assertNotNull("No action bar has been found", actionBar);
         assertFalse("Action bar is shown", actionBar.isShowing());
     }
@@ -62,6 +69,10 @@ public class ActionBarTest extends AbstractTest {
     public void test2() {
         // Open the drawer
         onView(withText(R.string.up)).perform(swipeUp());
+
+        // Wait for 500 milliseconds to wait for the resolution of events
+        final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(500);
+        IdlingRegistry.getInstance().register(waitingIdlingResource);
 
         // Check that action bar is showing
         final ActionBar actionBar = launcherActivityTestRule.getActivity().getActionBar();
@@ -78,6 +89,11 @@ public class ActionBarTest extends AbstractTest {
     public void test3() {
         // Open the drawer
         onView(withText(R.string.up)).perform(swipeUp());
+
+        // Wait for 500 milliseconds to wait for the resolution of events
+        final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(500);
+        IdlingRegistry.getInstance().register(waitingIdlingResource);
+
         // Open the action bar menu
         openActionBarOverflowOrOptionsMenu(launcherActivityTestRule.getActivity());
         // Toggle

--- a/launcher/src/androidTest/java/de/clemensbartz/android/launcher/DockTest.java
+++ b/launcher/src/androidTest/java/de/clemensbartz/android/launcher/DockTest.java
@@ -194,7 +194,7 @@ public class DockTest extends AbstractTest {
             assertNotNull("Launcher has been destroyed", launcher);
 
             // Wait for 500 second as icon loading is an asynchronous task
-            final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(1000);
+            final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(1500);
             IdlingRegistry.getInstance().register(waitingIdlingResource);
 
             // Check the actual text on the nth item

--- a/launcher/src/androidTest/java/de/clemensbartz/android/launcher/DockTest.java
+++ b/launcher/src/androidTest/java/de/clemensbartz/android/launcher/DockTest.java
@@ -194,7 +194,7 @@ public class DockTest extends AbstractTest {
             assertNotNull("Launcher has been destroyed", launcher);
 
             // Wait for 500 second as icon loading is an asynchronous task
-            final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(500);
+            final WaitingIdlingResource waitingIdlingResource = new WaitingIdlingResource(1000);
             IdlingRegistry.getInstance().register(waitingIdlingResource);
 
             // Check the actual text on the nth item

--- a/launcher/src/androidTest/java/de/clemensbartz/androidx/matcher/ContentDescriptionMatcher.java
+++ b/launcher/src/androidTest/java/de/clemensbartz/androidx/matcher/ContentDescriptionMatcher.java
@@ -51,7 +51,7 @@ final class ContentDescriptionMatcher extends TypeSafeMatcher<View> {
 
     @Override
     public void describeTo(final Description description) {
-        description.appendText("checks that content description is equal");
+        description.appendText("checks that content description is equal to " + contentDescription);
     }
 
     @Override

--- a/launcher/src/main/java/de/clemensbartz/android/launcher/Launcher.java
+++ b/launcher/src/main/java/de/clemensbartz/android/launcher/Launcher.java
@@ -119,7 +119,7 @@ public final class Launcher extends Activity {
         sharedPreferencesDAO = SharedPreferencesDAO.getInstance(getPreferences(Context.MODE_PRIVATE));
 
         // Set up view handling
-        viewController = new ViewController((ViewFlipper) findViewById(R.id.vsLauncher));
+        viewController = new ViewController((ViewFlipper) findViewById(R.id.vsLauncher), this, sharedPreferencesDAO);
         viewController.setStatusBarSystemService(SystemServiceUtil.getSystemServiceOrDefault(this, ViewController.SYSTEM_SERVICE_NAME_STATUS_BAR, null));
         gestureDetector = new GestureDetector(this, viewController);
 
@@ -401,6 +401,18 @@ public final class Launcher extends Activity {
 
                 viewController.showHome();
 
+                return true;
+            case R.id.abm_swipe_up:
+                if (viewController == null) {
+                    return super.onOptionsItemSelected(item);
+                }
+                viewController.requestGestureChange(ViewController.Gestures.SWIPE_UP);
+                return true;
+            case R.id.abm_swipe_down:
+                if (viewController == null) {
+                    return super.onOptionsItemSelected(item);
+                }
+                viewController.requestGestureChange(ViewController.Gestures.SWIPE_DOWN);
                 return true;
             case R.id.abm_grid_toggle:
                 if (viewController == null || sharedPreferencesDAO == null) {

--- a/launcher/src/main/res/menu/actionbar_options_menu.xml
+++ b/launcher/src/main/res/menu/actionbar_options_menu.xml
@@ -24,15 +24,25 @@
         android:icon="@drawable/ic_search"
         android:showAsAction="always|collapseActionView"
         android:title="@string/search" />
-    <item
-        android:id="@+id/abm_choose_widget"
-        android:title="@string/chooseWidget" />
-    <item
-        android:id="@+id/abm_layout_widget"
-        android:title="@string/layoutWidget" />
-    <item
-        android:id="@+id/abm_remove_widget"
-        android:title="@string/removeWidget" />
+    <group>
+        <item
+            android:id="@+id/abm_choose_widget"
+            android:title="@string/chooseWidget" />
+        <item
+            android:id="@+id/abm_layout_widget"
+            android:title="@string/layoutWidget" />
+        <item
+            android:id="@+id/abm_remove_widget"
+            android:title="@string/removeWidget" />
+    </group>
+    <group>
+        <item
+            android:id="@+id/abm_swipe_up"
+            android:title="@string/gestureSwipeUp" />
+        <item
+            android:id="@+id/abm_swipe_down"
+            android:title="@string/gestureSwipeDown" />
+    </group>
     <item
         android:id="@+id/abm_grid_toggle"
         android:checkable="true"

--- a/launcher/src/main/res/values/strings.xml
+++ b/launcher/src/main/res/values/strings.xml
@@ -39,4 +39,9 @@
     <string name="pinApp">Pin app…</string>
     <string name="search">Search</string>
     <string name="showAllDockIcons">Show all dock icons</string>
+    <string name="gestureSwipeUp" translatable="false">Swipe up gesture…</string>
+    <string name="gestureSwipeDown" translatable="false">Swipe down gesture…</string>
+    <string name="showStatusbar" translatable="false">Show notifications</string>
+    <string name="showDrawer" translatable="false">Show app drawer</string>
+    <string name="showSearch" translatable="false">Show search</string>
 </resources>


### PR DESCRIPTION
Fixes #78.

I have modified `ViewController`. Added an easily extendable `Gestures` `enum` for keys (swipeUp, swipeDown) and default values (drawer, notifications) of gestures.

`onLongPress` always launches app drawer to be able to edit settings.

Added `SHOW_STATUSBAR_ID, SHOW_DRAWER_ID, SHOW_SEARCH_ID ` for target pages and `showGestureTarget` to show them.

Swipe up/down items in action bar menu are used to assign new targets. 

(Sorry for the commit mess, I guess I need to sleep)